### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI - Lint & Format
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/M2tecDev/morpheus-link-bot/security/code-scanning/1](https://github.com/M2tecDev/morpheus-link-bot/security/code-scanning/1)

To fix the problem, explicitly declare restricted `GITHUB_TOKEN` permissions in the workflow. Since this CI job only checks out code and runs Ruff locally, it only needs read access to the repository contents. The best fix is to add a `permissions` block with `contents: read` at the top (workflow level), which will apply to all jobs that do not override it. This documents and enforces least privilege without changing any existing behavior.

Concretely, in `.github/workflows/ci.yml`, insert a `permissions:` section right after the `name:` (before the `on:` key). No imports or additional methods are needed; this is a pure YAML configuration change. The permissions block should look like:

```yaml
permissions:
  contents: read
```

This satisfies CodeQL’s recommendation and ensures the `GITHUB_TOKEN` used by this workflow cannot write to repository contents or other resources.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
