### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/M2tecDev/morpheus-link-bot/security/code-scanning/3](https://github.com/M2tecDev/morpheus-link-bot/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root (best here since there is only one job and all steps share the same minimal need).  
Use:

- `contents: read`

This preserves existing functionality (checkout and read-only CI tasks) while enforcing least privilege and satisfying CodeQL.

Change location: `.github/workflows/ci.yml`, immediately after the `on:` trigger block and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
